### PR TITLE
Removed ambiguity where the variable 'n' was used twice in two different contexts within the same definition

### DIFF
--- a/notes/dynamics.tex
+++ b/notes/dynamics.tex
@@ -534,7 +534,7 @@ copyright.
 	sets whose dimension we know: cubes.
 
 	\begin{definition}[Box Covering]
-		A $d$-dimensional \emph{box covering} of $X\subseteq \R^n$ is a collection $C=\Set{B_i}$ of 
+		A $d$-dimensional \emph{box covering} of $X\subseteq \R^k$ is a collection $C=\Set{B_i}$ of 
 		$d$-dimensional cubes which satisfy
 		\begin{enumerate}
 			\item if $i\neq j$, $B_i$ and $B_j$ intersect at most on their boundaries;
@@ -544,7 +544,7 @@ copyright.
 	\end{definition}
 
 	\begin{definition}[Outer Measure]
-		The \emph{$d$-dimensional outer measure} of $X\subseteq \R^n$ is
+		The \emph{$d$-dimensional outer measure} of $X\subseteq \R^k$ is
 		\[
 			\lim_{n\to\infty} \text{volume}(C_n)
 		\]


### PR DESCRIPTION
Currently, the definition is ambiguous--does the n refer to the dimensionality of the euclidean space, or to the limit variable?