### PR TITLE
Missing vector hats

### DIFF
--- a/notes/dynamics.tex
+++ b/notes/dynamics.tex
@@ -895,7 +895,7 @@ copyright.
 		if for all $\varepsilon>0$, there exists a $\delta>0$ so that for all $\vec y\in \R^n$, 
 		\[
 			\Norm{\vec x-\vec y} < \delta\qquad \text{implies}\qquad
-		\Norm{\phi_t(x)-\phi_t(y)} < \varepsilon \qquad \text{ for all }\qquad t > 0.
+		\Norm{\phi_t(\vec x)-\phi_t(\vec y)} < \varepsilon \qquad \text{ for all }\qquad t > 0.
 		\]
 		Otherwise, $\vec x$ is called \emph{unstable}.
 	\end{definition}


### PR DESCRIPTION
Vector hats are missing from the flows of x and y in the definition of point stability.